### PR TITLE
Fix initial spf13-vim clone.

### DIFF
--- a/tools/spf13-vim-windows-install.ps1
+++ b/tools/spf13-vim-windows-install.ps1
@@ -78,7 +78,7 @@ Try {
     {
         Write-Host "The spf13 application directory '$appDirectory' was not found."
         Set-Location $HOME
-        & $gitCommand clone --recursive -b 3.0 https://github.com/spf13/spf13-vim.git "$HOME"
+        & $gitCommand clone --recursive -b 3.0 https://github.com/spf13/spf13-vim.git "$appDirectory"
     } 
     Else
     {


### PR DESCRIPTION
Clone to $appDirectory rather than $HOME, which is a non-empty
directory. The clone would fail with, e.g.,  "fatal: destination path
'C:\Users\username' already exists and is not an empty directory'.

An initial install with `> choco install spf13-vim` results in the $HOME\.spf13-vim-3 directory containing only a .vim directory which itself contains an empty bundles directory. Package installation appears successful, as the errors occur in a separate PowerShell instance that then closes itself, but opening vim results in the vanilla white background with black text, and no plugins installed.

The error is due to an incorrect path for the initial spf13-vim repository clone, C:\Users\username instead of C:\Users\username\.spf-vim-3. The clone fails because the user directory is not empty: ![image](https://cloud.githubusercontent.com/assets/1808374/6993880/90af33ee-db04-11e4-99c7-3d3b15b7de78.png)

This error then causes the $HOME\.vim <==> $appDirectory\.vim symlink to be created as a file symlink instead of a directory symlink.

I think this is the same issue mentioned by "collegeimprovements me" and others in the package's [Disqus comments](https://disqus.com/home/discussions/chocolatey/chocolatey_gallery_spf13_vim_302/#comment-1778206226).
