### PR TITLE
New-SymLink doesn't create .vim directory symlink; cloned files erratically fail `Test-Path -PathType Container` check

### DIFF
--- a/tools/spf13-vim-windows-install.ps1
+++ b/tools/spf13-vim-windows-install.ps1
@@ -116,7 +116,6 @@ Try {
     # Create the symbolic links
     New-SymLink "$HOME\.vimrc" "$appDirectory\.vimrc"
     New-SymLink "$HOME\_vimrc" "$appDirectory\.vimrc"
-    New-SymLink "$HOME\_vimrc" "$appDirectory\.vimrc"
     New-SymLink "$HOME\.vimrc.fork" "$appDirectory\.vimrc.fork"
     New-SymLink "$HOME\.vimrc.bundles" "$appDirectory\.vimrc.bundles"
     New-SymLink "$HOME\.vimrc.bundles.fork" "$appDirectory\.vimrc.bundles.fork"


### PR DESCRIPTION
It seems that files created by a git clone aren't consistently visible to the current PowerShell session. On my computer, the `Test-Path -PathType Container` check in New-SymLink is always returning false, so the symlink for the $HOME.\spf13-vim\.vim directory to $HOME\.vim is being created without the /D flag, causing the vundle clone to fail.

I've added a file existence sanity-check to New-SymLink:

```
Function New-SymLink ($link, $target)
    If(!(test-path $target))
    {
        Write-Host "$target doesn't exist"
    }
    Else
    {
        Write-Host "$target exists"
    }
    [...]
```

and the results are inconsistent; some of the files pass it, while other files appear not to exist:

![image](https://cloud.githubusercontent.com/assets/1808374/6995350/d86f1504-db41-11e4-8244-ad7102333981.png)

What do you think about adding a parameter to New-SymLink, indicating what type of symlink to create?
